### PR TITLE
Enable configuration of address in Caddyfile

### DIFF
--- a/caddyprom.go
+++ b/caddyprom.go
@@ -70,11 +70,9 @@ func (m *Metrics) Provision(ctx caddy.Context) error {
 
 // UnmarshalCaddyfile -
 func (m *Metrics) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	// for d.Next() {
-	// 	if !d.Args(&m.Addr) {
-	// 		return d.ArgErr()
-	// 	}
-	// }
+	for d.Next() {
+		d.Args(&m.Addr)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is a small fix to allow configuration of the address to bind in Caddyfile with a line such as:

  prometheus 192.168.1.1:9180

while allowing the bare prometheus directive, without an address, to continue working.

(Warning: This is the first time I touch Go code. Handle with care!)